### PR TITLE
Cleanup and add executor's token balances. Add support for timeouts

### DIFF
--- a/scripts/createProposals.ts
+++ b/scripts/createProposals.ts
@@ -410,13 +410,13 @@ async function main() {
 
     const tweetText = `🔥Attention $ALLUO token holders!🔥
 
-It's time to make your voice heard!🗣️
+    It's time to make your voice heard!🗣️
 
-Vote where to invest deposits and reap the rewards from the difference in realised APY and what is paid to depositors!💰
+    Vote where to invest deposits and reap the rewards from the difference in realised APY and what is paid to depositors!💰
 
-Vote now at https://vote.alluo.com/
+    Vote now at https://vote.alluo.com/
 
-#ALLUO #liquiditydirection #governance`;
+    #ALLUO #liquiditydirection #governance`;
 
     await tweet([tweetText]);
 }


### PR DESCRIPTION
1. Now whenever this script is executed, the start time of the vote is whenever it is run. Previously, it was set to run at a fixed start time that was very inconvenient and with an end date that was misconfigured to end at an odd time.

Therefore, the vote will always end on Sunday 12 gmt, with all the correct params.

2. Cleaned up the code changes for emergency fixes. Added support for timeouts when API calls fail.

3. Calculate vote executor's balances. Only an issue for EUROC today.